### PR TITLE
Fix Create problem

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -102,7 +102,7 @@ class ProblemsController < ApplicationController
 
   def create
     params[:problem][:compiler_ids] ||= []
-    @problem = Problem.new(check_params(), setter: current_user)
+    @problem = Problem.new(check_params())
     @ban_compiler_ids = params[:problem][:compiler_ids].map(&:to_i).to_set
     respond_to do |format|
       if @problem.save


### PR DESCRIPTION
This pull request includes a minor change to the `edit` method in the `ProblemsController`. The change removes the `setter` attribute when initializing a new `Problem` object, simplifying the instantiation logic.

* [`app/controllers/problems_controller.rb`](diffhunk://#diff-6f929108fe47146937a112a8a84d5b96094970a3ebf09250f3ded6d517d3123dL105-R105): Removed the `setter: current_user` attribute from the `Problem.new` instantiation in the `create` method.