### PR TITLE
fix(ui): render sample testcases in correct monospaced font

### DIFF
--- a/app/assets/stylesheets/custom_styles.css
+++ b/app/assets/stylesheets/custom_styles.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "sf-pro";
-  src: url("SF-Pro.ttf");
+  src: url("/fonts/SF-Pro.ttf");
 }
 
 @font-face {

--- a/app/assets/stylesheets/custom_styles.css
+++ b/app/assets/stylesheets/custom_styles.css
@@ -1,6 +1,11 @@
 @font-face {
-  font-family: "monofont";
+  font-family: "sf-pro";
   src: url("SF-Pro.ttf");
+}
+
+@font-face {
+  font-family: "monofont";
+  src: url("/fonts/DejaVuSansMono.ttf");
 }
 
 .ds-panel {
@@ -56,7 +61,7 @@ th {
   color: #30617C;
 }
 body {
-  font-family: "monofont";
+  font-family: "sf-pro";
   background-color: #dde4ef;
   text-overflow: ellipsis;
 }
@@ -69,8 +74,8 @@ td {
 .well-lg .table {
   width: 100%;
 }
-h1 h2 h3 h4 h5 h6 {
-  font-family: "monofont";
+h1, h2, h3, h4, h5, h6 {
+  font-family: "sf-pro";
   color: #948C75;
 }
 .navbar-toggle {
@@ -249,8 +254,8 @@ tr.ole > td.highlight-if-self { /* dashboard self */
   color: #effafa !important;
 }
 
-// add this, but i don't know how to compile lol
-// - Huey
+/* add this, but i don't know how to compile lol
+   - Huey */
 body {
 	overflow-x: hidden;
 }

--- a/app/assets/stylesheets/custom_styles.css
+++ b/app/assets/stylesheets/custom_styles.css
@@ -74,9 +74,10 @@ td {
 .well-lg .table {
   width: 100%;
 }
-/* Very Strange is that this one is not working since missing comma between h1 h2 h3 h4 h5 h6,
- however, the result is correct since I don't want the color brown in h1, h2, h3, h4, h5, h6 
- The correct one should be h1, h2, h3, h4, h5, h6*/
+/* The following selector is missing commas between h1, h2, h3, h4, h5, and h6. 
+ This results in the styles not being applied as intended. However, this is acceptable 
+ in this case because the color brown is not desired for these elements. 
+ The correct syntax would be: h1, h2, h3, h4, h5, h6 */
 /* h1 h2 h3 h4 h5 h6 {
   font-family: "sf-pro";
   color: #948C75;

--- a/app/assets/stylesheets/custom_styles.css
+++ b/app/assets/stylesheets/custom_styles.css
@@ -74,10 +74,15 @@ td {
 .well-lg .table {
   width: 100%;
 }
-h1, h2, h3, h4, h5, h6 {
+/* Very Strange is that this one is not working since missing comma between h1 h2 h3 h4 h5 h6,
+ however, the result is correct since I don't want the color brown in h1, h2, h3, h4, h5, h6 
+ The correct one should be h1, h2, h3, h4, h5, h6*/
+/* h1 h2 h3 h4 h5 h6 {
   font-family: "sf-pro";
   color: #948C75;
-}
+} */
+
+
 .navbar-toggle {
   padding-top: 0px !important;
 }


### PR DESCRIPTION
This pull request updates the font styles in the `app/assets/stylesheets/custom_styles.css` file to improve consistency and readability across the application. The changes include replacing the primary font, adding a new font-face definition, and fixing minor syntax issues in comments.

### Font updates:

* Updated the primary font from `"monofont"` to `"sf-pro"` in multiple selectors, including `body`, `h1` through `h6` headers, and others to ensure a unified look and feel. (`[[1]](diffhunk://#diff-f13b18c03dbfe7f7e58a745e58d18d0aae567d4dfe14ba6bd172955348e57b6bL59-R64)`, `[[2]](diffhunk://#diff-f13b18c03dbfe7f7e58a745e58d18d0aae567d4dfe14ba6bd172955348e57b6bL72-R78)`)

* Added a new `@font-face` definition for `"monofont"` using the `DejaVuSansMono.ttf` file to maintain compatibility where `"monofont"` is still needed. (`[app/assets/stylesheets/custom_styles.cssL2-R10](diffhunk://#diff-f13b18c03dbfe7f7e58a745e58d18d0aae567d4dfe14ba6bd172955348e57b6bL2-R10)`)

### Syntax fixes:

* Corrected a comment block by converting an invalid `//` comment into a proper `/* */` block for better compatibility with CSS syntax. (`[app/assets/stylesheets/custom_styles.cssL252-R258](diffhunk://#diff-f13b18c03dbfe7f7e58a745e58d18d0aae567d4dfe14ba6bd172955348e57b6bL252-R258)`)
